### PR TITLE
python: release GIL during scanning

### DIFF
--- a/src/hyperscan/native.rs
+++ b/src/hyperscan/native.rs
@@ -90,11 +90,14 @@ impl StreamDatabase {
 pub struct Context<U> {
     user_data: U,
     match_error: Option<Error>,
-    match_event_handler: Box<dyn MatchEventHandler<U>>,
+    match_event_handler: Box<dyn MatchEventHandler<U> + Send>,
 }
 
 impl<U> Context<U> {
-    pub fn new(user_data: U, match_event_handler: impl MatchEventHandler<U> + 'static) -> Self {
+    pub fn new(
+        user_data: U,
+        match_event_handler: impl MatchEventHandler<U> + Send + 'static,
+    ) -> Self {
         Self {
             user_data,
             match_error: None,

--- a/src/hyperscan/wrapper.rs
+++ b/src/hyperscan/wrapper.rs
@@ -9,22 +9,22 @@ use std::{
 };
 
 foreign_type! {
-    unsafe type CompileError {
+    unsafe type CompileError: Send {
         type CType = hs::hs_compile_error_t;
         fn drop = hs::hs_free_compile_error;
     }
 
-    pub unsafe type Database: Send + Sync {
+    pub unsafe type Database: Send {
         type CType = hs::hs_database_t;
         fn drop = hs::hs_free_database;
     }
 
-    pub unsafe type Scratch {
+    pub unsafe type Scratch: Send {
         type CType = hs::hs_scratch_t;
         fn drop = hs::hs_free_scratch;
     }
 
-    pub unsafe type Stream {
+    pub unsafe type Stream: Send {
         type CType = hs::hs_stream_t;
         fn drop = stream_drop;
     }


### PR DESCRIPTION
As the scanners themselves are unsendable, the callbacks can only resurface on the original thread